### PR TITLE
fix issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ golang
 $ go get github.com/mattn/go-gimei
 ```
 
+## Running Tests
+
+To run all the tests, do:
+
+```bash
+$ go test
+```
+
 ## License
 
 MIT

--- a/example_test.go
+++ b/example_test.go
@@ -12,20 +12,20 @@ func ExampleGimeiName() {
 	fmt.Println(name.Kanji())
 	fmt.Println(name.Hiragana())
 	fmt.Println(name.Katakana())
+	fmt.Println(name.Last.Kanji())
+	fmt.Println(name.Last.Hiragana())
+	fmt.Println(name.Last.Katakana())
+	fmt.Println(name.First.Kanji())
+	fmt.Println(name.First.Hiragana())
+	fmt.Println(name.First.Katakana())
 	// Output:
 	// 小林 顕士
 	// 小林 顕士
 	// こばやし けんじ
 	// コバヤシ ケンジ
-	fmt.Println(name.Last.Kanji())
-	fmt.Println(name.Last.Hiragana())
-	fmt.Println(name.Last.Katakana())
 	// 小林
 	// こばやし
 	// コバヤシ
-	fmt.Println(name.First.Kanji())
-	fmt.Println(name.First.Hiragana())
-	fmt.Println(name.First.Katakana())
 	// 顕士
 	// けんじ
 	// ケンジ


### PR DESCRIPTION
ExampleGimeiName 関数の中で Output: で始まるコメントを関数の後方にまとめました。

[パッケージ testing の Examples についての説明](https://pkg.go.dev/testing#hdr-Examples) から該当する部分を以下に引用:

> Example functions may include _a concluding line comment_ that begins with "Output:" and is compared with the standard output of the function when the tests are run.