### PR TITLE
[CLI] fix is-female

### DIFF
--- a/cmd/gimei/main.go
+++ b/cmd/gimei/main.go
@@ -42,7 +42,7 @@ func doName(name *gimei.Name, args []string, sep string) {
 		case "is-male":
 			ret = fmt.Sprint(name.IsMale()) // false
 		case "is-female":
-			ret = fmt.Sprint(name.IsMale()) // false
+			ret = fmt.Sprint(name.IsFemale()) // false
 		}
 		if ret != "" {
 			if i > 0 {


### PR DESCRIPTION
以下のバグを修正します。

## バグの説明

CLI で is-female が is-male と同じ結果を出力する。

## 再現手順

CLI を以下のように実行すると true が出力されるべきだがそうならない。

```bash
$ go run ./cmd/gimei -type female is-female
false
```