### PR TITLE
Fix findNameByIndex

### DIFF
--- a/gimei.go
+++ b/gimei.go
@@ -225,7 +225,7 @@ func findNameByIndex(n string, i int) *Name {
 		return nil
 	}
 	for _, last := range names.LastName {
-		if last.Kanji() != token[0] {
+		if last[i] != token[0] {
 			continue
 		}
 		for _, first := range names.FirstName.Male {
@@ -252,17 +252,17 @@ func findNameByIndex(n string, i int) *Name {
 	return nil
 }
 
-// FindNameByKanji find Name from kanji.
+// FindNameByKanji find Name by kanji.
 func FindNameByKanji(kanji string) *Name {
 	return findNameByIndex(kanji, 0)
 }
 
-// FindNameByHiragana find Name from hiragana.
+// FindNameByHiragana find Name by hiragana.
 func FindNameByHiragana(hiragana string) *Name {
 	return findNameByIndex(hiragana, 1)
 }
 
-// FindNameByKanji find Name from katakana.
+// FindNameByKatakana find Name by katakana.
 func FindNameByKatakana(katakana string) *Name {
 	return findNameByIndex(katakana, 2)
 }
@@ -309,7 +309,7 @@ func (a *Address) Hiragana() string {
 	return a.Prefecture.Hiragana() + a.City.Hiragana() + a.Town.Hiragana()
 }
 
-// Hiragana return string of Address as katakana.
+// Katakana return string of Address as katakana.
 func (a *Address) Katakana() string {
 	return a.Prefecture.Katakana() + a.City.Katakana() + a.Town.Katakana()
 }
@@ -366,17 +366,17 @@ func findAddressByIndex(a string, i int) *Address {
 	return nil
 }
 
-// FindAddressByKanji find Address from kanji.
+// FindAddressByKanji find Address by kanji.
 func FindAddressByKanji(kanji string) *Address {
 	return findAddressByIndex(kanji, 0)
 }
 
-// FindAddressByHiragana find Address from hiragana.
+// FindAddressByHiragana find Address by hiragana.
 func FindAddressByHiragana(hiragana string) *Address {
 	return findAddressByIndex(hiragana, 1)
 }
 
-// FindAddressByKanji find Address from katakana.
+// FindAddressByKatakana find Address by katakana.
 func FindAddressByKatakana(katakana string) *Address {
 	return findAddressByIndex(katakana, 2)
 }

--- a/gimei_test.go
+++ b/gimei_test.go
@@ -37,3 +37,39 @@ func collectNewResults() []fmt.Stringer {
 
 	return s
 }
+
+func TestFindName(t *testing.T) {
+	var target string
+	name := gimei.NewName()
+
+	target = name.Kanji()
+	if gimei.FindNameByKanji(target) == nil {
+		t.Errorf("FindNameByKanji not found %s", target)
+	}
+	target = name.Hiragana()
+	if gimei.FindNameByHiragana(target) == nil {
+		t.Errorf("FindNameByHiragana not found %s", target)
+	}
+	target = name.Katakana()
+	if gimei.FindNameByKatakana(target) == nil {
+		t.Errorf("FindNameByKatakana not found: %s", target)
+	}
+}
+
+func TestFindAddress(t *testing.T) {
+	var target string
+	addr := gimei.NewAddress()
+
+	target = addr.Kanji()
+	if gimei.FindAddressByKanji(target) == nil {
+		t.Errorf("FindAddressByKanji not found %s", target)
+	}
+	target = addr.Hiragana()
+	if gimei.FindAddressByHiragana(target) == nil {
+		t.Errorf("FindAddressByHiragana not found %s", target)
+	}
+	target = addr.Katakana()
+	if gimei.FindAddressByKatakana(target) == nil {
+		t.Errorf("FindAddressByKatakana not found: %q", target)
+	}
+}


### PR DESCRIPTION
バグの修正とそのバグを再現するテストケース、及び関連する関数のコメント変更を含みます。

##  修正するバグについて

findNameByIndex() の引数 i に 1（= hiragana) や 2(= katakana) を与えた場合に、それぞれ hiraganaあるいは katakana でスキャンすることが期待されるが、常に kanji で比較する。
そのため当該関数を利用する FindNameByHiragana() と FindNameByKatakana() が予期せず kanji でスキャンしてしまう。

## テストケースの追加

以下の関数についてテストケースを追加した。

FindNameByKanji(), FindNameByHiragana(), FindNameByKanji() とその住所版である FindAddressByKanji(), FindAddressByHiragana(), FindAddressByKatakana() もついでに。

## コメントの変更

関数名とコメントが一致していないものと、（私の主観で恐縮ですが）前置詞をよりわかりやすく変更