### PR TITLE
use golang.org/x/text/cases instead.

### DIFF
--- a/gimei.go
+++ b/gimei.go
@@ -51,6 +51,9 @@ func (i Item) Katakana() string {
 
 // Romaji return string of Item as romaji.
 func (i Item) Romaji() string {
+	if len(i) <= 3 {
+		return ""
+	}
 	return cases.Title(language.Und, cases.NoLower).String(i[3])
 }
 

--- a/gimei.go
+++ b/gimei.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -49,7 +51,7 @@ func (i Item) Katakana() string {
 
 // Romaji return string of Item as romaji.
 func (i Item) Romaji() string {
-	return strings.Title(i[3])
+	return cases.Title(language.Und, cases.NoLower).String(i[3])
 }
 
 // Sex store Male or Female.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mattn/go-gimei
 
 go 1.16
 
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	golang.org/x/text v0.3.7
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Go 1.18 より strings.Title が deprecated されています。
この pull request では golang.org/x/text/cases を代わりに利用します。この代替ライブラリは Go 1.0 より利用可能です。